### PR TITLE
feat: submit event on item submission

### DIFF
--- a/contracts/GeneralizedTCR.sol
+++ b/contracts/GeneralizedTCR.sol
@@ -106,6 +106,8 @@ contract GeneralizedTCR is IArbitrable, IEvidence {
      */
     event ItemStatusChange(bytes32 indexed _itemID, uint _requestIndex, uint _roundIndex);
 
+    event ItemSubmitted(bytes32 indexed _itemID, bytes data);
+
     /**
      *  @dev Constructs the arbitrable curated registry.
      *  @param _arbitrator The trusted arbitrator to resolve potential disputes.
@@ -490,6 +492,8 @@ contract GeneralizedTCR is IArbitrable, IEvidence {
         if (item.requests.length == 0) {
             item.data = _item;
             itemList.push(itemID);
+
+            emit ItemSubmitted(itemID, item.data);
         }
         if (item.status == Status.Absent)
             item.status = Status.RegistrationRequested;

--- a/test/gtcr.js
+++ b/test/gtcr.js
@@ -175,22 +175,22 @@ contract('GTCR', function(accounts) {
     )
 
     assert.equal(
-      txAddItem.logs[0].event,
+      txAddItem.logs[1].event,
       'ItemStatusChange',
       'The event has not been created'
     )
     assert.equal(
-      txAddItem.logs[0].args._itemID,
+      txAddItem.logs[1].args._itemID,
       itemID,
       'The event has wrong item ID'
     )
     assert.equal(
-      txAddItem.logs[0].args._requestIndex.toNumber(),
+      txAddItem.logs[1].args._requestIndex.toNumber(),
       0,
       'The event has wrong request index'
     )
     assert.equal(
-      txAddItem.logs[0].args._roundIndex.toNumber(),
+      txAddItem.logs[1].args._roundIndex.toNumber(),
       0,
       'The event has wrong round index'
     )


### PR DESCRIPTION
This event is required to allow quickly searching items by their data.